### PR TITLE
fix: update app translation for Spanish

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
 	<string name="action_info">Información</string>
 	<string name="action_share">Compartir</string>
 	<string name="action_about">Acerca de</string>
-	<string name="app_name">Vía Rápida</string>
+	<string name="app_name">Fast Track</string>
 	<string name="intro_01_title">Ayuda Motivacional</string>
 	<string name="intro_00_title">¡Bienvenido a Fast Track!</string>
 	<string name="intro_00_description">¿De qué se trata esta aplicación?</string>


### PR DESCRIPTION
Application was translated to `Vía Rápida` "fast lane", which does not refer to anything related to `fasting` (ayuno 🇪🇸 ).
Keeping the original app name.