### PR TITLE
Change stage indicator to rhombus

### DIFF
--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLine.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLine.kt
@@ -9,7 +9,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.fasttrack.data.Phase
@@ -19,11 +22,11 @@ import kotlin.math.min
 import kotlin.time.Duration.Companion.hours
 
 val gaugeColors = listOf(
-	Color.White,
-	Color.Green,
-	Color.Yellow,
-	Color.Red,
-	Color.Magenta
+    Color.White,
+    Color.Green,
+    Color.Yellow,
+    Color.Red,
+    Color.Magenta
 )
 
 /**
@@ -31,133 +34,142 @@ val gaugeColors = listOf(
  */
 @Composable
 fun TimeLine(
-	elapsedHours: Double,
-	modifier: Modifier = Modifier,
-	onPhaseClick: (Phase) -> Unit = {}
+    elapsedHours: Double,
+    modifier: Modifier = Modifier,
+    onPhaseClick: (Phase) -> Unit = {}
 ) {
-	val padding = 16.dp
-	val spacing = 18.dp
-	val barSize = 16.dp
-	val needleSize = 3.dp
-	val needleRadius = 4.dp
+    val padding = 16.dp
+    val spacing = 4.dp // Reduced spacing since rhombuses connect
+    val barSize = 16.dp
+    val needleSize = 3.dp
+    val needleRadius = 4.dp
+    val slantOffset = 8.dp // How much the rhombus leans to the right
 
-	val outlineColor = MaterialTheme.colorScheme.onBackground
+    val outlineColor = MaterialTheme.colorScheme.onBackground
 
-	Canvas(
-		modifier = modifier
-			.fillMaxWidth()
-			.height(padding + barSize)
-			.pointerInput(Stages.phases) {
-				detectTapGestures { offset ->
-					val paddingPx = padding.toPx()
-					val spacingPx = spacing.toPx()
-					val barSizePx = barSize.toPx()
-					val availableWidth = size.width - paddingPx
-					val phaseWidth = (availableWidth / Stages.phases.size) - spacingPx
-					val startY = paddingPx
-					val yOk = abs(offset.y - startY) <= (barSizePx / 2f)
-					if (yOk) {
-						Stages.phases.forEachIndexed { index, phase ->
-							val startX = (index * phaseWidth) + (index * spacingPx) + paddingPx
-							val endX = startX + phaseWidth
-							if (offset.x in startX..endX) {
-								onPhaseClick(phase)
-								return@detectTapGestures
-							}
-						}
-					}
-				}
-			}
-	) {
-		val lastPhase = Stages.phases.last()
-		val lastPhaseHoursWeighted = lastPhase.hours * 1.5f
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(padding + barSize)
+            .pointerInput(Stages.phases) {
+                detectTapGestures { offset ->
+                    val paddingPx = padding.toPx()
+                    val spacingPx = spacing.toPx()
+                    val barSizePx = barSize.toPx()
+                    val availableWidth = size.width - paddingPx
+                    val phaseWidth = (availableWidth / Stages.phases.size) - spacingPx
+                    val startY = paddingPx
+                    val yOk = abs(offset.y - startY) <= (barSizePx / 2f)
+                    if (yOk) {
+                        Stages.phases.forEachIndexed { index, phase ->
+                            val startX = (index * phaseWidth) + (index * spacingPx) + paddingPx
+                            val endX = startX + phaseWidth
+                            if (offset.x in startX..endX) {
+                                onPhaseClick(phase)
+                                return@detectTapGestures
+                            }
+                        }
+                    }
+                }
+            }
+    ) {
+        val lastPhase = Stages.phases.last()
+        val lastPhaseHoursWeighted = lastPhase.hours * 1.5f
 
-		val availableWidth = size.width - padding.toPx()
-		val phaseWidth = (availableWidth / Stages.phases.size) - spacing.toPx()
+        val availableWidth = size.width - padding.toPx()
+        val phaseWidth = (availableWidth / Stages.phases.size) - spacing.toPx()
 
-		val curPhase = Stages.getCurrentPhase(elapsedHours.hours)
+        val curPhase = Stages.getCurrentPhase(elapsedHours.hours)
 
-		// Draw the bubbles (phases)
-		Stages.phases.forEachIndexed { index, phase ->
-			val startX = (index * phaseWidth) + (index * spacing.toPx()) + padding.toPx()
-			val startY = padding.toPx()
+        val slantOffsetPx = slantOffset.toPx()
+        val barSizePx = barSize.toPx()
 
-			// Current phase, thicket orange outline
-			if (curPhase == phase) {
-				// Outline
-				drawLine(
-					color = Color(0xFFE67E22),
-					start = Offset(startX, startY),
-					end = Offset(startX + phaseWidth, startY),
-					strokeWidth = barSize.toPx(),
-					cap = StrokeCap.Round
-				)
+        // Draw the rhombuses (phases)
+        Stages.phases.forEachIndexed { index, phase ->
+            val startX = (index * phaseWidth) + (index * spacing.toPx()) + padding.toPx()
+            val startY = padding.toPx()
 
-				// Current phase - filled
-				drawLine(
-					color = gaugeColors[index],
-					start = Offset(startX, startY),
-					end = Offset(startX + phaseWidth, startY),
-					strokeWidth = barSize.toPx() * 0.7f,
-					cap = StrokeCap.Round
-				)
-			} else {
-				// Other phases - thinner "onBackground" outline
+            // Create rhombus path (parallelogram leaning right)
+            val rhombusPath = Path().apply {
+                // Top left
+                moveTo(startX + slantOffsetPx, startY - barSizePx / 2)
+                // Top right
+                lineTo(startX + phaseWidth + slantOffsetPx, startY - barSizePx / 2)
+                // Bottom right
+                lineTo(startX + phaseWidth, startY + barSizePx / 2)
+                // Bottom left
+                lineTo(startX, startY + barSizePx / 2)
+                close()
+            }
 
-				// Thinner outline
-				drawLine(
-					color = outlineColor,
-					start = Offset(startX, startY),
-					end = Offset(startX + phaseWidth, startY),
-					strokeWidth = barSize.toPx(),
-					cap = StrokeCap.Round
-				)
+            // Current phase, thicker orange outline
+            if (curPhase == phase) {
+                // Outline
+                drawPath(
+                    path = rhombusPath,
+                    color = Color(0xFFE67E22),
+                    style = Stroke(width = 3.dp.toPx())
+                )
 
-				// Phase color
-				drawLine(
-					color = gaugeColors[index],
-					start = Offset(startX, startY),
-					end = Offset(startX + phaseWidth, startY),
-					strokeWidth = barSize.toPx() * 0.8f, // Slightly thinner
-					cap = StrokeCap.Round
-				)
-			}
-		}
+                // Current phase - filled
+                drawPath(
+                    path = rhombusPath,
+                    color = gaugeColors[index],
+                    style = Fill
+                )
+            } else {
+                // Other phases - thinner "onBackground" outline
 
-		// Draw the needle
-		if (elapsedHours > 0) {
-			val curPhaseIndex = Stages.phases.indexOf(curPhase)
-			val nextPhaseHours: Float = if (curPhaseIndex + 1 < Stages.phases.size) {
-				val nextPhase = Stages.phases[curPhaseIndex + 1]
-				nextPhase.hours.toFloat()
-			} else {
-				lastPhaseHoursWeighted
-			}
-			val phaseLength = (nextPhaseHours - curPhase.hours)
-			val timeIntoPhase = elapsedHours - curPhase.hours
+                // Outline
+                drawPath(
+                    path = rhombusPath,
+                    color = outlineColor,
+                    style = Stroke(width = 2.dp.toPx())
+                )
 
-			val percent = min(timeIntoPhase / phaseLength, 1.0)
+                // Phase color
+                drawPath(
+                    path = rhombusPath,
+                    color = gaugeColors[index],
+                    style = Fill
+                )
+            }
+        }
 
-			val halfPadding = padding.toPx() / 2f
+        // Draw the needle
+        if (elapsedHours > 0) {
+            val curPhaseIndex = Stages.phases.indexOf(curPhase)
+            val nextPhaseHours: Float = if (curPhaseIndex + 1 < Stages.phases.size) {
+                val nextPhase = Stages.phases[curPhaseIndex + 1]
+                nextPhase.hours.toFloat()
+            } else {
+                lastPhaseHoursWeighted
+            }
+            val phaseLength = (nextPhaseHours - curPhase.hours)
+            val timeIntoPhase = elapsedHours - curPhase.hours
 
-			val startX = (curPhaseIndex * phaseWidth) + (curPhaseIndex * spacing.toPx()) + padding.toPx()
-			val x = (startX + (phaseWidth * percent)).toFloat()
+            val percent = min(timeIntoPhase / phaseLength, 1.0)
 
-			// Draw needle line
-			drawLine(
-				color = Color.DarkGray,
-				start = Offset(x, halfPadding),
-				end = Offset(x, barSize.toPx() + halfPadding),
-				strokeWidth = needleSize.toPx(),
-				cap = StrokeCap.Square
-			)
+            val halfPadding = padding.toPx() / 2f
 
-			// Draw needle circle
-			drawCircle(
-				color = Color.DarkGray,
-				radius = needleRadius.toPx(),
-				center = Offset(x, barSize.toPx() + halfPadding + needleRadius.toPx())
-			)
-		}
-	}
+            val startX = (curPhaseIndex * phaseWidth) + (curPhaseIndex * spacing.toPx()) + padding.toPx()
+            val x = (startX + (phaseWidth * percent)).toFloat()
+
+            // Draw needle line
+            drawLine(
+                color = Color.DarkGray,
+                start = Offset(x, halfPadding),
+                end = Offset(x, barSize.toPx() + halfPadding),
+                strokeWidth = needleSize.toPx(),
+                cap = StrokeCap.Square
+            )
+
+            // Draw needle circle
+            drawCircle(
+                color = Color.DarkGray,
+                radius = needleRadius.toPx(),
+                center = Offset(x, barSize.toPx() + halfPadding + needleRadius.toPx())
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLine.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLine.kt
@@ -22,11 +22,11 @@ import kotlin.math.min
 import kotlin.time.Duration.Companion.hours
 
 val gaugeColors = listOf(
-    Color.White,
-    Color.Green,
-    Color.Yellow,
-    Color.Red,
-    Color.Magenta
+	Color.White,
+	Color.Green,
+	Color.Yellow,
+	Color.Red,
+	Color.Magenta
 )
 
 /**
@@ -34,142 +34,142 @@ val gaugeColors = listOf(
  */
 @Composable
 fun TimeLine(
-    elapsedHours: Double,
-    modifier: Modifier = Modifier,
-    onPhaseClick: (Phase) -> Unit = {}
+	elapsedHours: Double,
+	modifier: Modifier = Modifier,
+	onPhaseClick: (Phase) -> Unit = {}
 ) {
-    val padding = 16.dp
-    val spacing = 4.dp // Reduced spacing since rhombuses connect
-    val barSize = 16.dp
-    val needleSize = 3.dp
-    val needleRadius = 4.dp
-    val slantOffset = 8.dp // How much the rhombus leans to the right
+	val padding = 16.dp
+	val spacing = 4.dp // Reduced spacing since rhombuses connect
+	val barSize = 16.dp
+	val needleSize = 3.dp
+	val needleRadius = 4.dp
+	val slantOffset = 8.dp // How much the rhombus leans to the right
 
-    val outlineColor = MaterialTheme.colorScheme.onBackground
+	val outlineColor = MaterialTheme.colorScheme.onBackground
 
-    Canvas(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(padding + barSize)
-            .pointerInput(Stages.phases) {
-                detectTapGestures { offset ->
-                    val paddingPx = padding.toPx()
-                    val spacingPx = spacing.toPx()
-                    val barSizePx = barSize.toPx()
-                    val availableWidth = size.width - paddingPx
-                    val phaseWidth = (availableWidth / Stages.phases.size) - spacingPx
-                    val startY = paddingPx
-                    val yOk = abs(offset.y - startY) <= (barSizePx / 2f)
-                    if (yOk) {
-                        Stages.phases.forEachIndexed { index, phase ->
-                            val startX = (index * phaseWidth) + (index * spacingPx) + paddingPx
-                            val endX = startX + phaseWidth
-                            if (offset.x in startX..endX) {
-                                onPhaseClick(phase)
-                                return@detectTapGestures
-                            }
-                        }
-                    }
-                }
-            }
-    ) {
-        val lastPhase = Stages.phases.last()
-        val lastPhaseHoursWeighted = lastPhase.hours * 1.5f
+	Canvas(
+		modifier = modifier
+			.fillMaxWidth()
+			.height(padding + barSize)
+			.pointerInput(Stages.phases) {
+				detectTapGestures { offset ->
+					val paddingPx = padding.toPx()
+					val spacingPx = spacing.toPx()
+					val barSizePx = barSize.toPx()
+					val availableWidth = size.width - paddingPx
+					val phaseWidth = (availableWidth / Stages.phases.size) - spacingPx
+					val startY = paddingPx
+					val yOk = abs(offset.y - startY) <= (barSizePx / 2f)
+					if (yOk) {
+						Stages.phases.forEachIndexed { index, phase ->
+							val startX = (index * phaseWidth) + (index * spacingPx) + paddingPx
+							val endX = startX + phaseWidth
+							if (offset.x in startX..endX) {
+								onPhaseClick(phase)
+								return@detectTapGestures
+							}
+						}
+					}
+				}
+			}
+	) {
+		val lastPhase = Stages.phases.last()
+		val lastPhaseHoursWeighted = lastPhase.hours * 1.5f
 
-        val availableWidth = size.width - padding.toPx()
-        val phaseWidth = (availableWidth / Stages.phases.size) - spacing.toPx()
+		val availableWidth = size.width - padding.toPx()
+		val phaseWidth = (availableWidth / Stages.phases.size) - spacing.toPx()
 
-        val curPhase = Stages.getCurrentPhase(elapsedHours.hours)
+		val curPhase = Stages.getCurrentPhase(elapsedHours.hours)
 
-        val slantOffsetPx = slantOffset.toPx()
-        val barSizePx = barSize.toPx()
+		val slantOffsetPx = slantOffset.toPx()
+		val barSizePx = barSize.toPx()
 
-        // Draw the rhombuses (phases)
-        Stages.phases.forEachIndexed { index, phase ->
-            val startX = (index * phaseWidth) + (index * spacing.toPx()) + padding.toPx()
-            val startY = padding.toPx()
+		// Draw the rhombuses (phases)
+		Stages.phases.forEachIndexed { index, phase ->
+			val startX = (index * phaseWidth) + (index * spacing.toPx()) + padding.toPx()
+			val startY = padding.toPx()
 
-            // Create rhombus path (parallelogram leaning right)
-            val rhombusPath = Path().apply {
-                // Top left
-                moveTo(startX + slantOffsetPx, startY - barSizePx / 2)
-                // Top right
-                lineTo(startX + phaseWidth + slantOffsetPx, startY - barSizePx / 2)
-                // Bottom right
-                lineTo(startX + phaseWidth, startY + barSizePx / 2)
-                // Bottom left
-                lineTo(startX, startY + barSizePx / 2)
-                close()
-            }
+			// Create rhombus path (parallelogram leaning right)
+			val rhombusPath = Path().apply {
+				// Top left
+				moveTo(startX + slantOffsetPx, startY - barSizePx / 2)
+				// Top right
+				lineTo(startX + phaseWidth + slantOffsetPx, startY - barSizePx / 2)
+				// Bottom right
+				lineTo(startX + phaseWidth, startY + barSizePx / 2)
+				// Bottom left
+				lineTo(startX, startY + barSizePx / 2)
+				close()
+			}
 
-            // Current phase, thicker orange outline
-            if (curPhase == phase) {
-                // Outline
-                drawPath(
-                    path = rhombusPath,
-                    color = Color(0xFFE67E22),
-                    style = Stroke(width = 3.dp.toPx())
-                )
+			// Current phase, thicker orange outline
+			if (curPhase == phase) {
+				// Outline
+				drawPath(
+					path = rhombusPath,
+					color = Color(0xFFE67E22),
+					style = Stroke(width = 3.dp.toPx())
+				)
 
-                // Current phase - filled
-                drawPath(
-                    path = rhombusPath,
-                    color = gaugeColors[index],
-                    style = Fill
-                )
-            } else {
-                // Other phases - thinner "onBackground" outline
+				// Current phase - filled
+				drawPath(
+					path = rhombusPath,
+					color = gaugeColors[index],
+					style = Fill
+				)
+			} else {
+				// Other phases - thinner "onBackground" outline
 
-                // Outline
-                drawPath(
-                    path = rhombusPath,
-                    color = outlineColor,
-                    style = Stroke(width = 2.dp.toPx())
-                )
+				// Outline
+				drawPath(
+					path = rhombusPath,
+					color = outlineColor,
+					style = Stroke(width = 2.dp.toPx())
+				)
 
-                // Phase color
-                drawPath(
-                    path = rhombusPath,
-                    color = gaugeColors[index],
-                    style = Fill
-                )
-            }
-        }
+				// Phase color
+				drawPath(
+					path = rhombusPath,
+					color = gaugeColors[index],
+					style = Fill
+				)
+			}
+		}
 
-        // Draw the needle
-        if (elapsedHours > 0) {
-            val curPhaseIndex = Stages.phases.indexOf(curPhase)
-            val nextPhaseHours: Float = if (curPhaseIndex + 1 < Stages.phases.size) {
-                val nextPhase = Stages.phases[curPhaseIndex + 1]
-                nextPhase.hours.toFloat()
-            } else {
-                lastPhaseHoursWeighted
-            }
-            val phaseLength = (nextPhaseHours - curPhase.hours)
-            val timeIntoPhase = elapsedHours - curPhase.hours
+		// Draw the needle
+		if (elapsedHours > 0) {
+			val curPhaseIndex = Stages.phases.indexOf(curPhase)
+			val nextPhaseHours: Float = if (curPhaseIndex + 1 < Stages.phases.size) {
+				val nextPhase = Stages.phases[curPhaseIndex + 1]
+				nextPhase.hours.toFloat()
+			} else {
+				lastPhaseHoursWeighted
+			}
+			val phaseLength = (nextPhaseHours - curPhase.hours)
+			val timeIntoPhase = elapsedHours - curPhase.hours
 
-            val percent = min(timeIntoPhase / phaseLength, 1.0)
+			val percent = min(timeIntoPhase / phaseLength, 1.0)
 
-            val halfPadding = padding.toPx() / 2f
+			val halfPadding = padding.toPx() / 2f
 
-            val startX = (curPhaseIndex * phaseWidth) + (curPhaseIndex * spacing.toPx()) + padding.toPx()
-            val x = (startX + (phaseWidth * percent)).toFloat()
+			val startX = (curPhaseIndex * phaseWidth) + (curPhaseIndex * spacing.toPx()) + padding.toPx()
+			val x = (startX + (phaseWidth * percent)).toFloat()
 
-            // Draw needle line
-            drawLine(
-                color = Color.DarkGray,
-                start = Offset(x, halfPadding),
-                end = Offset(x, barSize.toPx() + halfPadding),
-                strokeWidth = needleSize.toPx(),
-                cap = StrokeCap.Square
-            )
+			// Draw needle line
+			drawLine(
+				color = Color.DarkGray,
+				start = Offset(x, halfPadding),
+				end = Offset(x, barSize.toPx() + halfPadding),
+				strokeWidth = needleSize.toPx(),
+				cap = StrokeCap.Square
+			)
 
-            // Draw needle circle
-            drawCircle(
-                color = Color.DarkGray,
-                radius = needleRadius.toPx(),
-                center = Offset(x, barSize.toPx() + halfPadding + needleRadius.toPx())
-            )
-        }
-    }
+			// Draw needle circle
+			drawCircle(
+				color = Color.DarkGray,
+				radius = needleRadius.toPx(),
+				center = Offset(x, barSize.toPx() + halfPadding + needleRadius.toPx())
+			)
+		}
+	}
 }


### PR DESCRIPTION
As mentioned by @atom-smasher in https://github.com/Wavesonics/FastTrack/issues/37 this UI change is more accurate considering how fasting stages change in the body. I personally think it also looks a bit cleaner too.

@Wavesonics Please suggest any changes or improvements if necessary. I just changed the draw logic here, nothing else.

<img width="316" height="701" alt="Screenshot 2026-01-21 at 09 11 07" src="https://github.com/user-attachments/assets/24f0cdb7-9fcb-40c5-aa79-766f91619ac9" />

