### PR TITLE
Fix AM/PM vs 24-hour clock inconsistency (issue #70)

### DIFF
--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/log/FastEntryItem.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/log/FastEntryItem.kt
@@ -22,6 +22,8 @@ import com.darkrockstudios.apps.fasttrack.data.log.FastingLogEntry
 import com.darkrockstudios.apps.fasttrack.screens.fasting.gaugeColors
 import com.darkrockstudios.apps.fasttrack.utils.formatAs
 import com.darkrockstudios.apps.fasttrack.utils.rememberVibrator
+import com.darkrockstudios.apps.fasttrack.utils.shouldUse24HourFormat
+import androidx.compose.ui.platform.LocalContext
 import kotlin.math.roundToInt
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
@@ -35,6 +37,8 @@ fun FastEntryItem(
 ) {
 	var showMenu by remember { mutableStateOf(false) }
 	val vibrator = rememberVibrator()
+	val context = LocalContext.current
+	val use24Hour = shouldUse24HourFormat(context)
 
 	Box {
 		Card(
@@ -53,8 +57,9 @@ fun FastEntryItem(
 			elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
 		) {
 			Column {
-				val dateStr = remember(entry.start) {
-					entry.start.formatAs("d MMM uuuu - HH:mm")
+				val dateStr = remember(entry.start, use24Hour) {
+					val timePattern = if (use24Hour) "HH:mm" else "h:mm a"
+					entry.start.formatAs("d MMM uuuu - $timePattern")
 				}
 
 				Text(

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/log/manualadd/ManualAddDialog.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/log/manualadd/ManualAddDialog.kt
@@ -20,7 +20,10 @@ import androidx.compose.ui.window.DialogProperties
 import com.darkrockstudios.apps.fasttrack.R
 import com.darkrockstudios.apps.fasttrack.screens.fasting.DateTimePickerDialog
 import com.darkrockstudios.apps.fasttrack.screens.fasting.rememberDateTimePickerDialogState
+import com.darkrockstudios.apps.fasttrack.screens.preview.getContext
 import com.darkrockstudios.apps.fasttrack.utils.PastAndTodaySelectableDates
+import com.darkrockstudios.apps.fasttrack.utils.formatAs
+import com.darkrockstudios.apps.fasttrack.utils.shouldUse24HourFormat
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toInstant
@@ -40,6 +43,7 @@ fun ManualAddDialog(
 	}
 
 	val uiState by viewModel.uiState.collectAsState()
+	val use24Hour = shouldUse24HourFormat(getContext())
 	var showEndDateTimePicker by remember { mutableStateOf(false) }
 
 	Dialog(
@@ -97,7 +101,8 @@ fun ManualAddDialog(
 				val initialMinute = uiState.selectedDateTime?.minute ?: 0
 				val timePickerState = rememberTimePickerState(
 					initialHour = initialHour,
-					initialMinute = initialMinute
+					initialMinute = initialMinute,
+					is24Hour = use24Hour,
 				)
 
 				when (uiState.currentStep) {
@@ -155,7 +160,7 @@ fun ManualAddDialog(
 									verticalAlignment = Alignment.CenterVertically
 								) {
 									Text(
-										text = "${dateTime.hour}:${dateTime.minute.toString().padStart(2, '0')}",
+										text = dateTime.formatAs(if (use24Hour) "HH:mm" else "h:mm a"),
 										style = MaterialTheme.typography.bodyLarge
 									)
 									Icon(


### PR DESCRIPTION
All time displays now respect the device's system clock format preference via the existing shouldUse24HourFormat() utility:
- ManualAddDialog: TimePicker now passes is24Hour; summary text uses locale-aware format instead of hardcoded 24-hour
- FastEntryItem: log entry time uses locale-aware pattern instead of hardcoded HH:mm