### PR TITLE
Move metric toggle from Profile to Settings (fixes #71)

### DIFF
--- a/app/src/androidTest/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileScreenComposeTest.kt
+++ b/app/src/androidTest/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileScreenComposeTest.kt
@@ -61,10 +61,8 @@ class ProfileScreenComposeTest {
 		composeTestRule.onNodeWithContentDescription(context.getString(R.string.bmr_info_button_description))
 			.assertExists()
 
-		// Height section with metric switch label
+		// Height section label
 		composeTestRule.onAllNodesWithText(context.getString(R.string.profile_height_label))
-			.assertCountEquals(1)
-		composeTestRule.onAllNodesWithText(context.getString(R.string.profile_metric_switch))
 			.assertCountEquals(1)
 
 		// Metric height input label
@@ -121,10 +119,8 @@ class ProfileScreenComposeTest {
 			}
 		}
 
-		// Height section labels
+		// Height section label
 		composeTestRule.onNodeWithText(context.getString(R.string.profile_height_label))
-			.assertExists()
-		composeTestRule.onNodeWithText(context.getString(R.string.profile_metric_switch))
 			.assertExists()
 
 		// Imperial height input labels exist

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/Data.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/Data.kt
@@ -10,6 +10,7 @@ object Data
 	const val KEY_FAST_ALERTS = "fast_alerts"
 	const val KEY_FANCY_BACKGROUND = "fancy_background"
 	const val KEY_FASTING_NOTIFICATION = "fasting_notification"
+	const val KEY_METRIC_SYSTEM = "metric_system"
 
 	private const val CM_INCH_RATIO = 2.54
 	fun inchToCm(inches: Int): Double = inches.toDouble() * CM_INCH_RATIO

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/Profile.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/Profile.kt
@@ -6,8 +6,7 @@ data class Profile(
 		val ageYears: Int = 0,
 		val heightCm: Double = 0.0,
 		val weightKg: Double = 0.0,
-		val gender: Gender = Gender.Male,
-		val displayMetric: Boolean = false): Serializable
+		val gender: Gender = Gender.Male): Serializable
 {
 	companion object
 	{

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsDatasource.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsDatasource.kt
@@ -16,4 +16,9 @@ interface SettingsDatasource {
 
 	fun getShowFastingNotification(): Boolean
 	fun setShowFastingNotification(enabled: Boolean)
+
+	fun getUseMetricSystem(default: Boolean): Boolean
+	fun setUseMetricSystem(enabled: Boolean)
+
+	fun useMetricSystemFlow(default: Boolean): Flow<Boolean>
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsPreferencesDatasource.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsPreferencesDatasource.kt
@@ -61,4 +61,23 @@ class SettingsPreferencesDatasource(
 	override fun setShowFastingNotification(enabled: Boolean) {
 		storage.edit { putBoolean(Data.KEY_FASTING_NOTIFICATION, enabled) }
 	}
+
+	override fun getUseMetricSystem(default: Boolean): Boolean =
+		storage.getBoolean(Data.KEY_METRIC_SYSTEM, default)
+
+	override fun setUseMetricSystem(enabled: Boolean) {
+		storage.edit { putBoolean(Data.KEY_METRIC_SYSTEM, enabled) }
+	}
+
+	override fun useMetricSystemFlow(default: Boolean): Flow<Boolean> = callbackFlow {
+		trySend(storage.getBoolean(Data.KEY_METRIC_SYSTEM, default))
+
+		val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+			if (key == Data.KEY_METRIC_SYSTEM) {
+				trySend(storage.getBoolean(Data.KEY_METRIC_SYSTEM, default))
+			}
+		}
+		storage.registerOnSharedPreferenceChangeListener(listener)
+		awaitClose { storage.unregisterOnSharedPreferenceChangeListener(listener) }
+	}
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/preview/DummySettingsDatasource.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/preview/DummySettingsDatasource.kt
@@ -27,4 +27,10 @@ class DummySettingsDatasource(
 	override fun getShowFastingNotification(): Boolean = true
 
 	override fun setShowFastingNotification(enabled: Boolean) {}
+
+	override fun getUseMetricSystem(default: Boolean): Boolean = default
+
+	override fun setUseMetricSystem(enabled: Boolean) {}
+
+	override fun useMetricSystemFlow(default: Boolean): Flow<Boolean> = flowOf(default)
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/IProfileViewModel.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/IProfileViewModel.kt
@@ -33,5 +33,4 @@ interface IProfileViewModel {
 	fun updateWeightLbs(value: String)
 	fun updateAge(value: String)
 	fun updateGender(value: Gender)
-	fun updateMetricSystem(isMetric: Boolean)
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileScreen.Preview.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileScreen.Preview.kt
@@ -343,5 +343,4 @@ class FakeProfileViewModel(state: IProfileViewModel.ProfileUiState) : IProfileVi
 	override fun updateWeightLbs(value: String) {}
 	override fun updateAge(value: String) {}
 	override fun updateGender(value: Gender) {}
-	override fun updateMetricSystem(isMetric: Boolean) {}
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -106,8 +105,7 @@ fun ProfileScreen(
 				onWeightKgChanged = viewModel::updateWeightKg,
 				onWeightLbsChanged = viewModel::updateWeightLbs,
 				onAgeChanged = viewModel::updateAge,
-				onGenderChanged = viewModel::updateGender,
-				onMetricSwitchChanged = viewModel::updateMetricSystem
+				onGenderChanged = viewModel::updateGender
 			)
 		}
 	}
@@ -211,8 +209,7 @@ fun ProfileDataEntryCard(
 	onWeightKgChanged: (String) -> Unit,
 	onWeightLbsChanged: (String) -> Unit,
 	onAgeChanged: (String) -> Unit,
-	onGenderChanged: (Gender) -> Unit,
-	onMetricSwitchChanged: (Boolean) -> Unit
+	onGenderChanged: (Gender) -> Unit
 ) {
 	Card(
 		modifier = Modifier
@@ -222,33 +219,12 @@ fun ProfileDataEntryCard(
 		Column(
 			modifier = Modifier.padding(16.dp)
 		) {
-			Row(
-				modifier = Modifier.fillMaxWidth(),
-				horizontalArrangement = Arrangement.SpaceBetween
-			) {
-				Text(
-					text = stringResource(id = R.string.profile_height_label),
-					style = MaterialTheme.typography.headlineMedium,
-					color = MaterialTheme.colorScheme.onSurface,
-					modifier = Modifier.padding(top = 16.dp)
-				)
-
-				Row(
-					horizontalArrangement = Arrangement.End,
-					verticalAlignment = Alignment.CenterVertically,
-				) {
-					Text(
-						text = stringResource(id = R.string.profile_metric_switch),
-						modifier = Modifier.padding(end = 8.dp),
-						style = MaterialTheme.typography.labelLarge,
-						color = MaterialTheme.colorScheme.onSurface,
-					)
-					Switch(
-						checked = isMetric,
-						onCheckedChange = onMetricSwitchChanged
-					)
-				}
-			}
+			Text(
+				text = stringResource(id = R.string.profile_height_label),
+				style = MaterialTheme.typography.headlineMedium,
+				color = MaterialTheme.colorScheme.onSurface,
+				modifier = Modifier.padding(top = 16.dp)
+			)
 
 			if (isMetric) {
 				// Metric Height Input

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileViewModel.kt
@@ -10,10 +10,12 @@ import com.darkrockstudios.apps.fasttrack.R
 import com.darkrockstudios.apps.fasttrack.data.Data
 import com.darkrockstudios.apps.fasttrack.data.Gender
 import com.darkrockstudios.apps.fasttrack.data.Profile
+import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.*
@@ -23,6 +25,7 @@ import kotlin.math.roundToInt
 
 class ProfileViewModel(
     private val appContext: Context,
+    private val settings: SettingsDatasource,
 ) : ViewModel(), IProfileViewModel {
 
     private val _uiState = MutableStateFlow(IProfileViewModel.ProfileUiState())
@@ -30,12 +33,14 @@ class ProfileViewModel(
 
     override fun onCreate() {
         viewModelScope.launch {
-            val profile = Satchel.storage.getOrSet(Data.KEY_PROFILE, Profile(displayMetric = isMetricSystem()))
-            populateUiState(profile)
+            settings.useMetricSystemFlow(default = isMetricSystemLocale()).collectLatest { isMetric ->
+                val profile = Satchel.storage.getOrSet(Data.KEY_PROFILE, Profile())
+                populateUiState(profile, isMetric)
+            }
         }
     }
 
-    private fun populateUiState(profile: Profile) {
+    private fun populateUiState(profile: Profile, isMetric: Boolean) {
         val totalInches = Data.cmToInch(profile.heightCm)
         val feet = floor(totalInches / 12.0).toInt()
         val inches = (totalInches % 12).toInt()
@@ -63,7 +68,7 @@ class ProfileViewModel(
 
         _uiState.update {
             it.copy(
-                isMetric = profile.displayMetric,
+                isMetric = isMetric,
                 heightCm = totalCmStr,
                 heightFeet = feetStr,
                 heightInches = inchesStr,
@@ -110,19 +115,6 @@ class ProfileViewModel(
     override fun updateGender(value: Gender) {
         _uiState.update { it.copy(gender = value) }
         validateAndSaveProfile()
-    }
-
-    override fun updateMetricSystem(isMetric: Boolean) {
-        val currentState = _uiState.value
-        val profile = createProfileFromUiState()
-
-        if (profile != null) {
-            _uiState.update { it.copy(isMetric = isMetric) }
-            populateUiState(profile.copy(displayMetric = isMetric))
-            validateAndSaveProfile()
-        } else {
-            _uiState.update { it.copy(isMetric = isMetric) }
-        }
     }
 
     private fun validateAndSaveProfile() {
@@ -217,7 +209,7 @@ class ProfileViewModel(
             Satchel.storage.apply {
                 set(Data.KEY_PROFILE, profile)
             }
-            populateUiState(profile)
+            populateUiState(profile, _uiState.value.isMetric)
             Napier.i("Profile saved")
         }
     }
@@ -248,8 +240,7 @@ class ProfileViewModel(
                 ageYears = age,
                 heightCm = totalCm,
                 weightKg = kg,
-                gender = currentState.gender,
-                displayMetric = currentState.isMetric
+                gender = currentState.gender
             )
         } else {
             null
@@ -303,7 +294,7 @@ class ProfileViewModel(
         return number
     }
 
-    private fun isMetricSystem(): Boolean {
+    private fun isMetricSystemLocale(): Boolean {
         val locale: Locale = LocaleList.getDefault()[0]
         val imperialCountries = listOf("US", "LR", "MM")
         return !imperialCountries.contains(locale.country)

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.LocaleList
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -31,6 +32,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 import java.io.File
+import java.util.Locale
 
 class SettingsActivity : AppCompatActivity() {
 	private val settings by inject<SettingsDatasource>()
@@ -41,6 +43,7 @@ class SettingsActivity : AppCompatActivity() {
 	private var pendingNotificationToggle = false
 	private var notificationSettingState by mutableStateOf(false)
 	private var stageAlertsSettingState by mutableStateOf(false)
+	private var metricSystemSettingState by mutableStateOf(false)
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -50,6 +53,7 @@ class SettingsActivity : AppCompatActivity() {
 
 		notificationSettingState = settings.getShowFastingNotification()
 		stageAlertsSettingState = settings.getFastingAlerts()
+		metricSystemSettingState = settings.getUseMetricSystem(default = isMetricSystemLocale())
 		registerNotificationPermissionCallback()
 		registerImportCallback()
 
@@ -62,6 +66,8 @@ class SettingsActivity : AppCompatActivity() {
 					onNotificationSettingChanged = { enabled -> handleNotificationSettingChange(enabled) },
 					stageAlertsSettingState = stageAlertsSettingState,
 					onStageAlertsSettingChanged = { enabled -> handleStageAlertsSettingChange(enabled) },
+					metricSystemSettingState = metricSystemSettingState,
+					onMetricSystemSettingChanged = { enabled -> handleMetricSystemSettingChange(enabled) },
 					onExportClick = { onExportLogBook() },
 					onImportClick = { onImportLogBook() }
 				)
@@ -141,6 +147,17 @@ class SettingsActivity : AppCompatActivity() {
 	private fun handleStageAlertsSettingChange(enabled: Boolean) {
 		settings.setFastingAlerts(enabled)
 		stageAlertsSettingState = enabled
+	}
+
+	private fun handleMetricSystemSettingChange(enabled: Boolean) {
+		settings.setUseMetricSystem(enabled)
+		metricSystemSettingState = enabled
+	}
+
+	private fun isMetricSystemLocale(): Boolean {
+		val locale: Locale = LocaleList.getDefault()[0]
+		val imperialCountries = listOf("US", "LR", "MM")
+		return !imperialCountries.contains(locale.country)
 	}
 
 	private fun registerImportCallback() {

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsScreen.kt
@@ -25,6 +25,8 @@ fun SettingsScreen(
 	onNotificationSettingChanged: (Boolean) -> Unit,
 	stageAlertsSettingState: Boolean,
 	onStageAlertsSettingChanged: (Boolean) -> Unit,
+	metricSystemSettingState: Boolean,
+	onMetricSystemSettingChanged: (Boolean) -> Unit,
 	onExportClick: () -> Unit,
 	onImportClick: () -> Unit
 ) {
@@ -55,6 +57,8 @@ fun SettingsScreen(
 			onNotificationSettingChanged = onNotificationSettingChanged,
 			stageAlertsSettingState = stageAlertsSettingState,
 			onStageAlertsSettingChanged = onStageAlertsSettingChanged,
+			metricSystemSettingState = metricSystemSettingState,
+			onMetricSystemSettingChanged = onMetricSystemSettingChanged,
 			onExportClick = onExportClick,
 			onImportClick = onImportClick
 		)
@@ -69,6 +73,8 @@ private fun SettingsList(
 	onNotificationSettingChanged: (Boolean) -> Unit,
 	stageAlertsSettingState: Boolean,
 	onStageAlertsSettingChanged: (Boolean) -> Unit,
+	metricSystemSettingState: Boolean,
+	onMetricSystemSettingChanged: (Boolean) -> Unit,
 	onExportClick: () -> Unit,
 	onImportClick: () -> Unit
 ) {
@@ -117,6 +123,14 @@ private fun SettingsList(
 						fancyBackground = checked
 						settings.setShowFancyBackground(checked)
 					}
+				)
+			}
+			item(key = "metric_system") {
+				SettingsItem(
+					headline = R.string.settings_metric_system_title,
+					details = R.string.settings_metric_system_subtitle,
+					value = metricSystemSettingState,
+					onChange = onMetricSystemSettingChanged
 				)
 			}
 			item(key = "logbook_header") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,6 +299,8 @@
 	<string name="back">Back</string>
 	<string name="settings_fancy_background_title">Show Fancy Background</string>
 	<string name="settings_fancy_background_subtitle">Disable for a simpler Fasting background</string>
+	<string name="settings_metric_system_title">Metric System</string>
+	<string name="settings_metric_system_subtitle">Display height and weight in metric units</string>
 	<string name="log_no_entries">No entries yet!</string>
 	<string name="log_logbook_label">Logbook</string>
 	<string name="log_stats_label">Lifetime stats</string>

--- a/app/src/test/java/com/darkrockstudios/apps/fasttrack/data/settings/FakeSettingsDatasource.kt
+++ b/app/src/test/java/com/darkrockstudios/apps/fasttrack/data/settings/FakeSettingsDatasource.kt
@@ -12,6 +12,7 @@ class FakeSettingsDatasource : SettingsDatasource {
 	private var introSeen: Boolean = false
 	private var showFancyBackground: Boolean = false
 	private var showFastingNotification: Boolean = true
+	private var useMetricSystem: Boolean? = null
 
 	override fun getFastingAlerts(): Boolean = fastingAlerts
 
@@ -39,6 +40,15 @@ class FakeSettingsDatasource : SettingsDatasource {
 		showFastingNotification = enabled
 	}
 
+	override fun getUseMetricSystem(default: Boolean): Boolean = useMetricSystem ?: default
+
+	override fun setUseMetricSystem(enabled: Boolean) {
+		useMetricSystem = enabled
+	}
+
+	override fun useMetricSystemFlow(default: Boolean): Flow<Boolean> =
+		flowOf(getUseMetricSystem(default))
+
 	/**
 	 * Clears all data - useful for test setup/teardown
 	 */
@@ -47,5 +57,6 @@ class FakeSettingsDatasource : SettingsDatasource {
 		introSeen = false
 		showFancyBackground = false
 		showFastingNotification = true
+		useMetricSystem = null
 	}
 }


### PR DESCRIPTION
Relocates the Metric units switch from the Profile screen to the Settings screen for consistency with other app preferences. Metric preference now lives in SettingsDatasource with a locale-based default and a flow so the Profile screen reactively repopulates height/weight display when the preference changes.