### PR TITLE
Add dark mode with System/Light/Dark selector

### DIFF
--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/Data.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/Data.kt
@@ -11,6 +11,7 @@ object Data
 	const val KEY_FANCY_BACKGROUND = "fancy_background"
 	const val KEY_FASTING_NOTIFICATION = "fasting_notification"
 	const val KEY_METRIC_SYSTEM = "metric_system"
+	const val KEY_THEME_MODE = "theme_mode"
 
 	private const val CM_INCH_RATIO = 2.54
 	fun inchToCm(inches: Int): Double = inches.toDouble() * CM_INCH_RATIO

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsDatasource.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsDatasource.kt
@@ -21,4 +21,7 @@ interface SettingsDatasource {
 	fun setUseMetricSystem(enabled: Boolean)
 
 	fun useMetricSystemFlow(default: Boolean): Flow<Boolean>
+
+	fun getThemeMode(): ThemeMode
+	fun setThemeMode(mode: ThemeMode)
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsPreferencesDatasource.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/SettingsPreferencesDatasource.kt
@@ -80,4 +80,11 @@ class SettingsPreferencesDatasource(
 		storage.registerOnSharedPreferenceChangeListener(listener)
 		awaitClose { storage.unregisterOnSharedPreferenceChangeListener(listener) }
 	}
+
+	override fun getThemeMode(): ThemeMode =
+		ThemeMode.fromName(storage.getString(Data.KEY_THEME_MODE, null))
+
+	override fun setThemeMode(mode: ThemeMode) {
+		storage.edit { putString(Data.KEY_THEME_MODE, mode.name) }
+	}
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/ThemeMode.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/data/settings/ThemeMode.kt
@@ -1,0 +1,12 @@
+package com.darkrockstudios.apps.fasttrack.data.settings
+
+enum class ThemeMode {
+	SYSTEM,
+	LIGHT,
+	DARK;
+
+	companion object {
+		fun fromName(name: String?): ThemeMode =
+			entries.firstOrNull { it.name == name } ?: SYSTEM
+	}
+}

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/FastingScreenStyling.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/FastingScreenStyling.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.fasttrack.screens.fasting
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -8,6 +7,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.fasttrack.ui.theme.LocalDarkTheme
 import com.darkrockstudios.apps.fasttrack.ui.theme.Purple100
 import com.darkrockstudios.apps.fasttrack.ui.theme.Purple700
 
@@ -16,7 +16,7 @@ val phaseTextColor_Dark = Purple100
 
 @Composable
 fun phaseTextColor(): Color {
-	val isDark: Boolean = isSystemInDarkTheme()
+	val isDark: Boolean = LocalDarkTheme.current
 	return if (isDark) {
 		phaseTextColor_Dark
 	} else {

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/info/InfoActivity.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/info/InfoActivity.kt
@@ -13,16 +13,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.core.view.WindowCompat
 import com.darkrockstudios.apps.fasttrack.R
+import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
 import com.darkrockstudios.apps.fasttrack.ui.theme.FastTrackTheme
+import org.koin.android.ext.android.inject
 
 class InfoActivity : AppCompatActivity() {
+	private val settings by inject<SettingsDatasource>()
+
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 		WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = false
 
 		setContent {
-			FastTrackTheme {
+			FastTrackTheme(themeMode = settings.getThemeMode()) {
 				Scaffold(
 					topBar = {
 						TopAppBar(

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/intro/IntroActivity.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/intro/IntroActivity.kt
@@ -34,12 +34,15 @@ import androidx.core.content.edit
 import androidx.core.view.WindowCompat
 import com.darkrockstudios.apps.fasttrack.R
 import com.darkrockstudios.apps.fasttrack.data.Data
+import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
 import com.darkrockstudios.apps.fasttrack.ui.theme.FastTrackTheme
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 
 class IntroActivity : AppCompatActivity() {
     private val storage by lazy { PreferenceManager.getDefaultSharedPreferences(this) }
+	private val settings by inject<SettingsDatasource>()
 	private lateinit var requestNotificationPermission: ActivityResultLauncher<String>
 	private var shouldRequestPermission by mutableStateOf(false)
 
@@ -53,7 +56,7 @@ class IntroActivity : AppCompatActivity() {
 	    registerNotificationPermissionCallback()
 
         setContent {
-            FastTrackTheme {
+            FastTrackTheme(themeMode = settings.getThemeMode()) {
                 IntroScreen(
 	                onComplete = { complete() },
 	                onNotificationSlideExited = { requestNotificationPermissionIfNeeded() }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/main/MainActivity.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/main/MainActivity.kt
@@ -18,6 +18,7 @@ import com.darkrockstudios.apps.fasttrack.R
 import com.darkrockstudios.apps.fasttrack.data.Stages
 import com.darkrockstudios.apps.fasttrack.data.activefast.ActiveFastRepository
 import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
+import com.darkrockstudios.apps.fasttrack.data.settings.ThemeMode
 import com.darkrockstudios.apps.fasttrack.screens.fasting.ExternalRequests
 import com.darkrockstudios.apps.fasttrack.screens.fasting.StartFastRequest
 import com.darkrockstudios.apps.fasttrack.screens.info.InfoActivity
@@ -33,6 +34,7 @@ import kotlin.time.ExperimentalTime
 class MainActivity : AppCompatActivity() {
 	private var startFastRequestState by mutableStateOf<StartFastRequest?>(null)
 	private var stopFastRequestState by mutableStateOf(false)
+	private var themeModeState by mutableStateOf(ThemeMode.SYSTEM)
 	private val settings by inject<SettingsDatasource>()
 	private val fastingRepository by inject<ActiveFastRepository>()
 
@@ -43,6 +45,7 @@ class MainActivity : AppCompatActivity() {
 		WindowCompat.getInsetsController(window, window.decorView)
 			.isAppearanceLightStatusBars = false
 
+		themeModeState = settings.getThemeMode()
 		handleStartFastExtra(intent)
 
 		if (!settings.getIntroSeen()) {
@@ -50,7 +53,7 @@ class MainActivity : AppCompatActivity() {
 		}
 
 		setContent {
-			FastTrackTheme {
+			FastTrackTheme(themeMode = themeModeState) {
 				MainScreen(
 					repository = fastingRepository,
 					onShareClick = { shareText() },
@@ -70,6 +73,10 @@ class MainActivity : AppCompatActivity() {
 
 	override fun onStart() {
 		super.onStart()
+		val currentMode = settings.getThemeMode()
+		if (currentMode != themeModeState) {
+			themeModeState = currentMode
+		}
 		setupFastingNotification()
 	}
 

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/preview/DummySettingsDatasource.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/preview/DummySettingsDatasource.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.fasttrack.screens.preview
 
 import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
+import com.darkrockstudios.apps.fasttrack.data.settings.ThemeMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -33,4 +34,8 @@ class DummySettingsDatasource(
 	override fun setUseMetricSystem(enabled: Boolean) {}
 
 	override fun useMetricSystemFlow(default: Boolean): Flow<Boolean> = flowOf(default)
+
+	override fun getThemeMode(): ThemeMode = ThemeMode.SYSTEM
+
+	override fun setThemeMode(mode: ThemeMode) {}
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsActivity.kt
@@ -25,6 +25,7 @@ import com.darkrockstudios.apps.fasttrack.R
 import com.darkrockstudios.apps.fasttrack.data.activefast.ActiveFastRepository
 import com.darkrockstudios.apps.fasttrack.data.log.FastingLogRepository
 import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
+import com.darkrockstudios.apps.fasttrack.data.settings.ThemeMode
 import com.darkrockstudios.apps.fasttrack.ui.theme.FastTrackTheme
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Dispatchers
@@ -44,6 +45,7 @@ class SettingsActivity : AppCompatActivity() {
 	private var notificationSettingState by mutableStateOf(false)
 	private var stageAlertsSettingState by mutableStateOf(false)
 	private var metricSystemSettingState by mutableStateOf(false)
+	private var themeModeState by mutableStateOf(ThemeMode.SYSTEM)
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -54,11 +56,12 @@ class SettingsActivity : AppCompatActivity() {
 		notificationSettingState = settings.getShowFastingNotification()
 		stageAlertsSettingState = settings.getFastingAlerts()
 		metricSystemSettingState = settings.getUseMetricSystem(default = isMetricSystemLocale())
+		themeModeState = settings.getThemeMode()
 		registerNotificationPermissionCallback()
 		registerImportCallback()
 
 		setContent {
-			FastTrackTheme {
+			FastTrackTheme(themeMode = themeModeState) {
 				SettingsScreen(
 					onBack = { finish() },
 					settings = settings,
@@ -68,6 +71,8 @@ class SettingsActivity : AppCompatActivity() {
 					onStageAlertsSettingChanged = { enabled -> handleStageAlertsSettingChange(enabled) },
 					metricSystemSettingState = metricSystemSettingState,
 					onMetricSystemSettingChanged = { enabled -> handleMetricSystemSettingChange(enabled) },
+					themeModeState = themeModeState,
+					onThemeModeChanged = { mode -> handleThemeModeChange(mode) },
 					onExportClick = { onExportLogBook() },
 					onImportClick = { onImportLogBook() }
 				)
@@ -152,6 +157,13 @@ class SettingsActivity : AppCompatActivity() {
 	private fun handleMetricSystemSettingChange(enabled: Boolean) {
 		settings.setUseMetricSystem(enabled)
 		metricSystemSettingState = enabled
+	}
+
+	private fun handleThemeModeChange(mode: ThemeMode) {
+		if (mode == themeModeState) return
+		settings.setThemeMode(mode)
+		themeModeState = mode
+		recreate()
 	}
 
 	private fun isMetricSystemLocale(): Boolean {

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/settings/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -14,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.darkrockstudios.apps.fasttrack.R
 import com.darkrockstudios.apps.fasttrack.data.settings.SettingsDatasource
+import com.darkrockstudios.apps.fasttrack.data.settings.ThemeMode
 import com.darkrockstudios.apps.fasttrack.utils.MAX_COLUMN_WIDTH
 
 
@@ -27,6 +29,8 @@ fun SettingsScreen(
 	onStageAlertsSettingChanged: (Boolean) -> Unit,
 	metricSystemSettingState: Boolean,
 	onMetricSystemSettingChanged: (Boolean) -> Unit,
+	themeModeState: ThemeMode,
+	onThemeModeChanged: (ThemeMode) -> Unit,
 	onExportClick: () -> Unit,
 	onImportClick: () -> Unit
 ) {
@@ -59,6 +63,8 @@ fun SettingsScreen(
 			onStageAlertsSettingChanged = onStageAlertsSettingChanged,
 			metricSystemSettingState = metricSystemSettingState,
 			onMetricSystemSettingChanged = onMetricSystemSettingChanged,
+			themeModeState = themeModeState,
+			onThemeModeChanged = onThemeModeChanged,
 			onExportClick = onExportClick,
 			onImportClick = onImportClick
 		)
@@ -75,6 +81,8 @@ private fun SettingsList(
 	onStageAlertsSettingChanged: (Boolean) -> Unit,
 	metricSystemSettingState: Boolean,
 	onMetricSystemSettingChanged: (Boolean) -> Unit,
+	themeModeState: ThemeMode,
+	onThemeModeChanged: (ThemeMode) -> Unit,
 	onExportClick: () -> Unit,
 	onImportClick: () -> Unit
 ) {
@@ -131,6 +139,12 @@ private fun SettingsList(
 					details = R.string.settings_metric_system_subtitle,
 					value = metricSystemSettingState,
 					onChange = onMetricSystemSettingChanged
+				)
+			}
+			item(key = "theme_mode") {
+				ThemeModeSettingsItem(
+					themeMode = themeModeState,
+					onThemeModeChanged = onThemeModeChanged
 				)
 			}
 			item(key = "logbook_header") {
@@ -196,6 +210,65 @@ private fun SettingsItem(
 				checked = value,
 				onCheckedChange = onChange
 			)
+		}
+	)
+}
+
+@Composable
+private fun ThemeModeSettingsItem(
+	themeMode: ThemeMode,
+	onThemeModeChanged: (ThemeMode) -> Unit
+) {
+	var expanded by remember { mutableStateOf(false) }
+	val labelRes = when (themeMode) {
+		ThemeMode.SYSTEM -> R.string.settings_theme_mode_system
+		ThemeMode.LIGHT -> R.string.settings_theme_mode_light
+		ThemeMode.DARK -> R.string.settings_theme_mode_dark
+	}
+
+	ListItem(
+		headlineContent = {
+			Text(
+				text = stringResource(id = R.string.settings_theme_mode_title),
+				style = MaterialTheme.typography.labelLarge,
+				fontWeight = FontWeight.Bold
+			)
+		},
+		supportingContent = {
+			Text(
+				text = stringResource(id = R.string.settings_theme_mode_subtitle),
+				style = MaterialTheme.typography.bodySmall
+			)
+		},
+		trailingContent = {
+			Box {
+				TextButton(onClick = { expanded = true }) {
+					Text(stringResource(id = labelRes))
+					Icon(
+						imageVector = Icons.Filled.ArrowDropDown,
+						contentDescription = null
+					)
+				}
+				DropdownMenu(
+					expanded = expanded,
+					onDismissRequest = { expanded = false }
+				) {
+					ThemeMode.entries.forEach { mode ->
+						val itemLabel = when (mode) {
+							ThemeMode.SYSTEM -> R.string.settings_theme_mode_system
+							ThemeMode.LIGHT -> R.string.settings_theme_mode_light
+							ThemeMode.DARK -> R.string.settings_theme_mode_dark
+						}
+						DropdownMenuItem(
+							text = { Text(stringResource(id = itemLabel)) },
+							onClick = {
+								expanded = false
+								onThemeModeChanged(mode)
+							}
+						)
+					}
+				}
+			}
 		}
 	)
 }

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/ui/theme/Gradient.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/ui/theme/Gradient.kt
@@ -1,7 +1,6 @@
 package com.darkrockstudios.apps.fasttrack.ui.theme
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Brush
@@ -11,9 +10,9 @@ import androidx.compose.ui.graphics.Color
 val LightGradientStartColor = Color(0xFFE9DBFF) // #E9DBFF
 val LightGradientEndColor = Color(0xFFC2D7FF) // #C2D7FF
 
-// Colors from fast_background.xml (dark mode)
-val DarkGradientStartColor = Color(0xFF4E447A) // #4E447A
-val DarkGradientEndColor = Color(0xFF8E8E8E) // #8E8E8E
+// Dark mode gradient
+val DarkGradientStartColor = Color(0xFF2A1F3D)
+val DarkGradientEndColor = Color(0xFF1A1A1A)
 
 /**
  * Extension function to apply the fast background gradient to a Modifier.
@@ -31,7 +30,7 @@ val DarkGradientEndColor = Color(0xFF8E8E8E) // #8E8E8E
  */
 fun Modifier.fastBackgroundGradient(show: Boolean): Modifier = composed {
 	if (show) {
-		val isDarkTheme = isSystemInDarkTheme()
+		val isDarkTheme = LocalDarkTheme.current
 
 		val startColor = if (isDarkTheme) DarkGradientStartColor else LightGradientStartColor
 		val endColor = if (isDarkTheme) DarkGradientEndColor else LightGradientEndColor

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/ui/theme/Theme.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/ui/theme/Theme.kt
@@ -5,6 +5,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.darkrockstudios.apps.fasttrack.data.settings.ThemeMode
+
+val LocalDarkTheme = staticCompositionLocalOf { false }
 
 private val LightColorScheme = lightColorScheme(
 	primary = Purple500,
@@ -60,18 +65,29 @@ private val DarkColorScheme = darkColorScheme(
 
 @Composable
 fun FastTrackTheme(
-	darkTheme: Boolean = isSystemInDarkTheme(),
+	themeMode: ThemeMode = ThemeMode.SYSTEM,
 	content: @Composable () -> Unit
 ) {
-	val colorScheme = if (darkTheme) {
-		DarkColorScheme
-	} else {
-		LightColorScheme
+	val darkTheme = when (themeMode) {
+		ThemeMode.SYSTEM -> isSystemInDarkTheme()
+		ThemeMode.LIGHT -> false
+		ThemeMode.DARK -> true
 	}
+	FastTrackTheme(darkTheme = darkTheme, content = content)
+}
 
-	MaterialTheme(
-		colorScheme = colorScheme,
-		shapes = Shapes,
-		content = content
-	)
+@Composable
+fun FastTrackTheme(
+	darkTheme: Boolean,
+	content: @Composable () -> Unit
+) {
+	val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+
+	CompositionLocalProvider(LocalDarkTheme provides darkTheme) {
+		MaterialTheme(
+			colorScheme = colorScheme,
+			shapes = Shapes,
+			content = content
+		)
+	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -301,6 +301,11 @@
 	<string name="settings_fancy_background_subtitle">Disable for a simpler Fasting background</string>
 	<string name="settings_metric_system_title">Metric System</string>
 	<string name="settings_metric_system_subtitle">Display height and weight in metric units</string>
+	<string name="settings_theme_mode_title">Theme</string>
+	<string name="settings_theme_mode_subtitle">Choose light, dark, or follow system</string>
+	<string name="settings_theme_mode_system">System</string>
+	<string name="settings_theme_mode_light">Light</string>
+	<string name="settings_theme_mode_dark">Dark</string>
 	<string name="log_no_entries">No entries yet!</string>
 	<string name="log_logbook_label">Logbook</string>
 	<string name="log_stats_label">Lifetime stats</string>

--- a/app/src/test/java/com/darkrockstudios/apps/fasttrack/data/settings/FakeSettingsDatasource.kt
+++ b/app/src/test/java/com/darkrockstudios/apps/fasttrack/data/settings/FakeSettingsDatasource.kt
@@ -13,6 +13,7 @@ class FakeSettingsDatasource : SettingsDatasource {
 	private var showFancyBackground: Boolean = false
 	private var showFastingNotification: Boolean = true
 	private var useMetricSystem: Boolean? = null
+	private var themeMode: ThemeMode = ThemeMode.SYSTEM
 
 	override fun getFastingAlerts(): Boolean = fastingAlerts
 
@@ -49,6 +50,12 @@ class FakeSettingsDatasource : SettingsDatasource {
 	override fun useMetricSystemFlow(default: Boolean): Flow<Boolean> =
 		flowOf(getUseMetricSystem(default))
 
+	override fun getThemeMode(): ThemeMode = themeMode
+
+	override fun setThemeMode(mode: ThemeMode) {
+		themeMode = mode
+	}
+
 	/**
 	 * Clears all data - useful for test setup/teardown
 	 */
@@ -58,5 +65,6 @@ class FakeSettingsDatasource : SettingsDatasource {
 		showFancyBackground = false
 		showFastingNotification = true
 		useMetricSystem = null
+		themeMode = ThemeMode.SYSTEM
 	}
 }


### PR DESCRIPTION
Builds on the work from #60 but replaces the boolean checkbox with a dropdown that offers System (follow OS), Light, and Dark.

- ThemeMode enum persisted via SharedPreferences
- FastTrackTheme resolves mode to dark/light; LocalDarkTheme exposed for composables that need to branch on it (gradient, phase text)
- SettingsActivity recreates on mode change to apply the new theme