### PR TITLE
Use consistent naming on profile page (fixes #72)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,11 +106,11 @@
 	<string name="log_entry_autophagy">Autophagy: %1$d hours</string>
 
 	<string name="profile_age_label">Age</string>
-	<string name="profile_age_years">years</string>
+	<string name="profile_age_years">Years</string>
 
 	<string name="profile_weight_label">Weight</string>
 	<string name="profile_weight_pounds_label">Pounds</string>
-	<string name="profile_weight_kg_label">Kg</string>
+	<string name="profile_weight_kg_label">Kilograms</string>
 
 	<string name="profile_update_button">Update</string>
 
@@ -125,12 +125,12 @@
 	<string name="profile_error">Bad Value</string>
 
 	<string name="profile_bmr_label">BMR:</string>
-	<string name="profile_bmr_value">%.0f kCal / day</string>
+	<string name="profile_bmr_value">%.0f kcal / day</string>
 
 	<string name="profile_height_label">Height</string>
 	<string name="profile_height_imper_feet_label">Feet</string>
 	<string name="profile_height_imper_inches_label">Inches</string>
-	<string name="profile_height_metric_label">Cm</string>
+	<string name="profile_height_metric_label">Centimeters</string>
 	<string name="profile_gender_male">Male</string>
 	<string name="profile_gender_female">Female</string>
 	<string name="manual_add_title">Manual Add</string>


### PR DESCRIPTION
## Summary
- Match metric unit labels to imperial style: `Cm` → `Centimeters`, `Kg` → `Kilograms` (imperial already uses Feet, Inches, Pounds).
- Capitalize `years` → `Years` to match other unit labels.
- Fix `kCal` → `kcal` (standard SI symbol) in the BMR value.

Fixes #72. Only the English source (`values/strings.xml`) was edited — translations flow through Crowdin and will resync from these source strings.

## Test plan
- [ ] Open the Profile screen and confirm the height/weight/age/gender labels read `Centimeters`, `Kilograms`, `Years`.
- [ ] Confirm BMR displays as `kcal / day`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)