### PR TITLE
Parse weight using locale-aware decimal separator (fixes #62)

### DIFF
--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileViewModel.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.text.NumberFormat
+import java.text.ParseException
 import java.util.*
 import kotlin.math.floor
 import kotlin.math.pow
@@ -283,15 +285,18 @@ class ProfileViewModel(
     }
 
     private fun parseDouble(text: String?): Double {
-        var number = 0.0
-        text?.let {
-            try {
-                number = text.toDouble()
-            } catch (e: NumberFormatException) {
-                Napier.w("Failed to parse double")
-            }
+        if (text.isNullOrEmpty()) return 0.0
+        try {
+            return text.toDouble()
+        } catch (e: NumberFormatException) {
+            // Fall through to locale-aware parsing for separators like ","
         }
-        return number
+        return try {
+            NumberFormat.getInstance().parse(text)?.toDouble() ?: 0.0
+        } catch (e: ParseException) {
+            Napier.w("Failed to parse double")
+            0.0
+        }
     }
 
     private fun isMetricSystemLocale(): Boolean {

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/profile/ProfileViewModel.kt
@@ -277,7 +277,7 @@ class ProfileViewModel(
         text?.let {
             try {
                 number = text.toInt()
-            } catch (e: NumberFormatException) {
+            } catch (_: NumberFormatException) {
                 Napier.w("Failed to parse int")
             }
         }
@@ -286,16 +286,15 @@ class ProfileViewModel(
 
     private fun parseDouble(text: String?): Double {
         if (text.isNullOrEmpty()) return 0.0
-        try {
-            return text.toDouble()
-        } catch (e: NumberFormatException) {
-            // Fall through to locale-aware parsing for separators like ","
-        }
         return try {
-            NumberFormat.getInstance().parse(text)?.toDouble() ?: 0.0
-        } catch (e: ParseException) {
-            Napier.w("Failed to parse double")
-            0.0
+            text.toDouble()
+        } catch (_: NumberFormatException) {
+            try {
+                NumberFormat.getInstance().parse(text)?.toDouble() ?: 0.0
+            } catch (_: ParseException) {
+                Napier.w("Failed to parse double")
+                0.0
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- In locales that use `,` as the decimal separator (e.g. Dutch), typing a weight like `50,5` produced a "Bad Value" error, because `parseDouble` in `ProfileViewModel` called `String.toDouble()`, which only accepts `.`.
- The displayed values are already formatted with the default locale (`"%.01f".format(...)`), so parsing now matches: try `toDouble()` first (fast path and covers stored `.`-formatted values), then fall back to `NumberFormat.getInstance().parse()` for locale-specific separators.

Fixes #62

## Test plan
- [ ] Set device locale to Dutch (nl-NL), open Profile, enter weight `50,5` — no "Bad Value" error, BMI/BMR recalculate.
- [ ] Set device locale to English (en-US), enter weight `50.5` — still parses correctly.
- [ ] Clear the field — no crash, value treated as empty/invalid as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)