### PR TITLE
Share TimeLine geometry between hit testing and drawing

### DIFF
--- a/app/src/androidTest/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLineTapTest.kt
+++ b/app/src/androidTest/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLineTapTest.kt
@@ -1,0 +1,91 @@
+package com.darkrockstudios.apps.fasttrack.screens.fasting
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.fasttrack.data.Phase
+import com.darkrockstudios.apps.fasttrack.data.Stages
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Taps land on the phase they visually cover. Expected coordinates are written out longhand rather
+ * than reusing the production geometry, so a change to the bar layout has to be made deliberately.
+ */
+@RunWith(AndroidJUnit4::class)
+class TimeLineTapTest {
+
+	@get:Rule
+	val composeTestRule = createComposeRule()
+
+	private fun phaseCenterX(index: Int) = START_OFFSET + index * PHASE_STRIDE + PHASE_WIDTH / 2f
+
+	private fun content(clicked: MutableList<Phase>) {
+		// The blink animation never settles, so the clock has to be driven by hand.
+		composeTestRule.mainClock.autoAdvance = false
+		composeTestRule.setContent {
+			CompositionLocalProvider(LocalDensity provides Density(density = 2f, fontScale = 1f)) {
+				Box(modifier = Modifier.size(360.dp, 64.dp)) {
+					TimeLine(
+						elapsedHours = 30.0,
+						modifier = Modifier.testTag(TAG),
+						onPhaseClick = { clicked += it }
+					)
+				}
+			}
+		}
+	}
+
+	private fun tap(x: Float, y: Float) {
+		composeTestRule.onNodeWithTag(TAG).performTouchInput { click(Offset(x, y)) }
+	}
+
+	@Test
+	fun tappingEachPhaseCenterReportsThatPhase() {
+		val clicked = mutableListOf<Phase>()
+		content(clicked)
+
+		Stages.phases.indices.forEach { index -> tap(phaseCenterX(index), CENTER_Y) }
+
+		assertEquals(Stages.phases.toList(), clicked)
+	}
+
+	@Test
+	fun tappingAboveOrBelowTheBarIsIgnored() {
+		val clicked = mutableListOf<Phase>()
+		content(clicked)
+
+		tap(phaseCenterX(2), CENTER_Y - BAR_HALF - 4f)
+		tap(phaseCenterX(2), CENTER_Y + BAR_HALF + 4f)
+
+		assertTrue(clicked.toString(), clicked.isEmpty())
+	}
+
+	private companion object {
+		const val TAG = "timeline"
+
+		// 360 dp wide at density 2 -> 720 px. padding 16 dp = 32 px, spacing 4 dp = 8 px,
+		// slant 8 dp = 16 px, bar 16 dp = 32 px.
+		// phaseWidth = (720 - 2*32 - 4*8) / 5 = 124.8
+		// totalWidth = 5*124.8 + 4*8 + 16 = 672, so startOffset = (720 - 672) / 2 = 24
+		const val PHASE_WIDTH = 124.8f
+		const val PHASE_STRIDE = PHASE_WIDTH + 8f
+		const val START_OFFSET = 24f
+		const val CENTER_Y = 32f
+		const val BAR_HALF = 16f
+	}
+}

--- a/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLine.kt
+++ b/app/src/main/java/com/darkrockstudios/apps/fasttrack/screens/fasting/TimeLine.kt
@@ -5,23 +5,29 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
 import com.darkrockstudios.apps.fasttrack.data.Phase
 import com.darkrockstudios.apps.fasttrack.data.Stages
 import kotlin.math.abs
@@ -36,6 +42,57 @@ val gaugeColors = listOf(
 	Color.Magenta
 )
 
+private val Padding = 16.dp
+private val Spacing = 4.dp
+private val BarSize = 16.dp
+private val NeedleSize = 3.dp
+private val NeedleRadius = 4.dp
+private val SlantOffset = 8.dp
+
+private val CurrentPhaseStroke = 3.dp
+private val PhaseStroke = 2.dp
+
+private val BlinkFromColor = Color(0xFFE67E22)
+private val BlinkToColor = Color.Yellow
+
+/**
+ * Pixel layout of the phase bar. Shared by hit testing and drawing so tap targets always line up
+ * with what is on screen.
+ */
+private class TimeLineGeometry(density: Density, size: Size) {
+	val spacingPx = with(density) { Spacing.toPx() }
+	val slantOffsetPx = with(density) { SlantOffset.toPx() }
+	val barSizePx = with(density) { BarSize.toPx() }
+	val centerY = with(density) { Padding.toPx() }
+
+	val phaseWidth: Float
+	private val startOffset: Float
+
+	init {
+		val paddingPx = with(density) { Padding.toPx() }
+		val count = Stages.phases.size
+		phaseWidth = (size.width - (2 * paddingPx) - (count - 1) * spacingPx) / count
+		val totalWidth = (count * phaseWidth) + ((count - 1) * spacingPx) + slantOffsetPx
+		startOffset = (size.width - totalWidth) / 2f
+	}
+
+	fun startX(index: Int): Float = startOffset + index * (phaseWidth + spacingPx)
+
+	fun endX(index: Int): Float = startX(index) + phaseWidth + slantOffsetPx
+
+	fun rhombusPath(index: Int): Path {
+		val startX = startX(index)
+		val halfBar = barSizePx / 2
+		return Path().apply {
+			moveTo(startX + slantOffsetPx, centerY - halfBar)
+			lineTo(startX + phaseWidth + slantOffsetPx, centerY - halfBar)
+			lineTo(startX + phaseWidth, centerY + halfBar)
+			lineTo(startX, centerY + halfBar)
+			close()
+		}
+	}
+}
+
 /**
  * Fasting Stages view
  */
@@ -45,20 +102,12 @@ fun TimeLine(
 	modifier: Modifier = Modifier,
 	onPhaseClick: (Phase) -> Unit = {}
 ) {
-	val padding = 16.dp
-	val spacing = 4.dp
-	val barSize = 16.dp
-	val needleSize = 3.dp
-	val needleRadius = 4.dp
-	val slantOffset = 8.dp
-
 	val outlineColor = MaterialTheme.colorScheme.onBackground
-	
 	val curPhase = Stages.getCurrentPhase(elapsedHours.hours)
-	
+
 	// Continuous blink animation for current phase
 	val infiniteTransition = rememberInfiniteTransition(label = "phase_blink")
-	val blinkProgress by infiniteTransition.animateFloat(
+	val blinkProgress = infiniteTransition.animateFloat(
 		initialValue = 0f,
 		targetValue = 1f,
 		animationSpec = infiniteRepeatable(
@@ -68,123 +117,98 @@ fun TimeLine(
 		label = "blink_progress"
 	)
 
-	Canvas(
+	// Read through State inside the draw block so the per-frame blink and the ~100Hz timer updates
+	// redraw without rebuilding the cached paths.
+	val elapsedState = rememberUpdatedState(elapsedHours)
+	val curPhaseState = rememberUpdatedState(curPhase)
+	val outlineColorState = rememberUpdatedState(outlineColor)
+	val onPhaseClickState = rememberUpdatedState(onPhaseClick)
+
+	Spacer(
 		modifier = modifier
 			.fillMaxWidth()
-			.height(padding + barSize)
-			.pointerInput(curPhase) {
+			.height(Padding + BarSize)
+			.pointerInput(Unit) {
 				detectTapGestures { offset ->
-					val paddingPx = padding.toPx()
-					val spacingPx = spacing.toPx()
-					val barSizePx = barSize.toPx()
-					val slantOffsetPx = slantOffset.toPx()
-					
-					val phaseWidth = (size.width - (2 * paddingPx) - (Stages.phases.size - 1) * spacingPx) / Stages.phases.size
-					val totalWidth = (Stages.phases.size * phaseWidth) + ((Stages.phases.size - 1) * spacingPx) + slantOffsetPx
-					val startOffset = (size.width - totalWidth) / 2f
-					
-					val startY = paddingPx
-					val yOk = abs(offset.y - startY) <= (barSizePx / 2f)
-					if (yOk) {
-						Stages.phases.forEachIndexed { index, phase ->
-							val startX = startOffset + (index * phaseWidth) + (index * spacingPx)
-							val endX = startX + phaseWidth + slantOffsetPx
-							if (offset.x in startX..endX) {
-								onPhaseClick(phase)
-								return@detectTapGestures
-							}
+					val geometry = TimeLineGeometry(this, size.toSize())
+					if (abs(offset.y - geometry.centerY) > geometry.barSizePx / 2f) {
+						return@detectTapGestures
+					}
+					Stages.phases.forEachIndexed { index, phase ->
+						if (offset.x in geometry.startX(index)..geometry.endX(index)) {
+							onPhaseClickState.value(phase)
+							return@detectTapGestures
 						}
 					}
 				}
 			}
-	) {
-		val lastPhase = Stages.phases.last()
-		val lastPhaseHoursWeighted = lastPhase.hours * 1.5f
+			.drawTimeLine(elapsedState, curPhaseState, outlineColorState, blinkProgress)
+	)
+}
 
-		val slantOffsetPx = slantOffset.toPx()
-		val barSizePx = barSize.toPx()
-		
-		val phaseWidth = (size.width - (2 * padding.toPx()) - (Stages.phases.size - 1) * spacing.toPx()) / Stages.phases.size
-		val totalWidth = (Stages.phases.size * phaseWidth) + ((Stages.phases.size - 1) * spacing.toPx()) + slantOffsetPx
-		
-		val startOffset = (size.width - totalWidth) / 2f
+private fun Modifier.drawTimeLine(
+	elapsedHours: State<Double>,
+	curPhase: State<Phase>,
+	outlineColor: State<Color>,
+	blinkProgress: State<Float>,
+): Modifier = drawWithCache {
+	val geometry = TimeLineGeometry(this, size)
+	val paths = Stages.phases.indices.map(geometry::rhombusPath)
 
+	onDrawBehind {
+		val current = curPhase.value
 		Stages.phases.forEachIndexed { index, phase ->
-			val startX = startOffset + (index * phaseWidth) + (index * spacing.toPx())
-			val startY = padding.toPx()
+			drawPath(path = paths[index], color = gaugeColors[index], style = Fill)
 
-			val rhombusPath = Path().apply {
-				moveTo(startX + slantOffsetPx, startY - barSizePx / 2)
-				lineTo(startX + phaseWidth + slantOffsetPx, startY - barSizePx / 2)
-				lineTo(startX + phaseWidth, startY + barSizePx / 2)
-				lineTo(startX, startY + barSizePx / 2)
-				close()
-			}
-
-			if (curPhase == phase) {
-				drawPath(
-					path = rhombusPath,
-					color = gaugeColors[index],
-					style = Fill
+			val isCurrent = phase == current
+			drawPath(
+				path = paths[index],
+				color = if (isCurrent) {
+					lerp(BlinkFromColor, BlinkToColor, blinkProgress.value)
+				} else {
+					outlineColor.value
+				},
+				style = Stroke(
+					width = (if (isCurrent) CurrentPhaseStroke else PhaseStroke).toPx()
 				)
-				
-				// Continuously animate between orange and yellow
-				val baseOutlineColor = Color(0xFFE67E22) // Orange
-				val blinkColor = Color.Yellow
-				val currentOutlineColor = lerp(baseOutlineColor, blinkColor, blinkProgress)
-				
-				drawPath(
-					path = rhombusPath,
-					color = currentOutlineColor,
-					style = Stroke(width = 3.dp.toPx())
-				)
-			} else {
-				drawPath(
-					path = rhombusPath,
-					color = gaugeColors[index],
-					style = Fill
-				)
-				
-				drawPath(
-					path = rhombusPath,
-					color = outlineColor,
-					style = Stroke(width = 2.dp.toPx())
-				)
-			}
+			)
 		}
 
-		// Draw the needle
-		if (elapsedHours > 0) {
-			val curPhaseIndex = Stages.phases.indexOf(curPhase)
-			val nextPhaseHours: Float = if (curPhaseIndex + 1 < Stages.phases.size) {
-				val nextPhase = Stages.phases[curPhaseIndex + 1]
-				nextPhase.hours.toFloat()
-			} else {
-				lastPhaseHoursWeighted
-			}
-			val phaseLength = (nextPhaseHours - curPhase.hours)
-			val timeIntoPhase = elapsedHours - curPhase.hours
-
-			val percent = min(timeIntoPhase / phaseLength, 1.0)
-
-			val halfPadding = padding.toPx() / 2f
-
-			val startX = startOffset + (curPhaseIndex * phaseWidth) + (curPhaseIndex * spacing.toPx())
-			val x = (startX + (phaseWidth * percent)).toFloat()
-
-			drawLine(
-				color = Color.DarkGray,
-				start = Offset(x, halfPadding),
-				end = Offset(x, barSize.toPx() + halfPadding),
-				strokeWidth = needleSize.toPx(),
-				cap = StrokeCap.Square
-			)
-
-			drawCircle(
-				color = Color.DarkGray,
-				radius = needleRadius.toPx(),
-				center = Offset(x, barSize.toPx() + halfPadding + needleRadius.toPx())
-			)
+		val elapsed = elapsedHours.value
+		if (elapsed > 0) {
+			drawNeedle(geometry, current, elapsed)
 		}
 	}
+}
+
+private fun DrawScope.drawNeedle(
+	geometry: TimeLineGeometry,
+	curPhase: Phase,
+	elapsedHours: Double,
+) {
+	val curPhaseIndex = Stages.phases.indexOf(curPhase)
+	val nextPhaseHours: Float = if (curPhaseIndex + 1 < Stages.phases.size) {
+		Stages.phases[curPhaseIndex + 1].hours.toFloat()
+	} else {
+		Stages.phases.last().hours * 1.5f
+	}
+	val phaseLength = nextPhaseHours - curPhase.hours
+	val percent = min((elapsedHours - curPhase.hours) / phaseLength, 1.0)
+
+	val halfPadding = Padding.toPx() / 2f
+	val x = (geometry.startX(curPhaseIndex) + (geometry.phaseWidth * percent)).toFloat()
+
+	drawLine(
+		color = Color.DarkGray,
+		start = Offset(x, halfPadding),
+		end = Offset(x, BarSize.toPx() + halfPadding),
+		strokeWidth = NeedleSize.toPx(),
+		cap = StrokeCap.Square
+	)
+
+	drawCircle(
+		color = Color.DarkGray,
+		radius = NeedleRadius.toPx(),
+		center = Offset(x, BarSize.toPx() + halfPadding + NeedleRadius.toPx())
+	)
 }


### PR DESCRIPTION
Addresses the two Codacy findings on the timeline that were flagged in #59 but were not introduced by it.

## Shared geometry

The phase width, spacing and offset math was computed twice, once in the tap handler and once in the draw block. They happened to agree, but nothing kept them that way. Both now go through `TimeLineGeometry`, which owns the layout and hands out `startX` / `endX` / `rhombusPath` per phase.

## Cheaper drawing

The blink is an `infiniteRepeatable`, so the bar redraws continuously while the fasting screen is up. Previously each frame allocated five `Path` objects plus a `Color`, and reading `blinkProgress` in the composable body recomposed `TimeLine` on every frame.

Paths now build in `drawWithCache` and only rebuild when the size changes. The blink, elapsed time and outline color are read through `State` inside the draw block, so the bar redraws without recomposing. This matters more than it looks: `FastingScreen` runs `viewModel.updateUi(); delay(10)` while a fast is active, so `elapsedHours` changes about 100 times a second and was invalidating the whole composable each time.

## Verification

Rendered the fasting screen at 23 viewport sizes (200x320 up to 1280x800, plus 1.5x and 2.0x font scales) before and after, and diffed the bitmaps. 21 of 23 are byte identical. The other 2 differ by 48 and 43 pixels at a maximum channel delta of 1/255, on the antialiased edges of the info icons, which is rasterization noise rather than a layout change.

`TimeLineTapTest` covers the phase hit boxes with coordinates written out longhand rather than reusing the production geometry, so a layout change has to be made deliberately. It passes against `main` unchanged as well, so it characterizes existing behavior rather than the refactor.

Full instrumented suite green (10 tests).

## Not included

Two other things turned up on this screen while measuring, both pre-existing and both left alone here:

- Below roughly 300 dp wide the timer overflows and wraps, because `isCompact` switches typography on height only. `BasicText` with `TextAutoSize.StepBased` fixes it.
- `spacing` is 4 dp while `slantOffset` is 8 dp, so adjacent phases overlap by 4 dp both visually and in their tap regions, and the earlier phase wins a tap in the overlap. Preserved exactly as is, since it reads as intentional.